### PR TITLE
OP-1880: Packaging updates to decrease restart time and not remove unit files in script.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ansi_term"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -113,7 +113,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -192,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -214,9 +213,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "log"
@@ -238,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -285,9 +284,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "os_str_bytes"
@@ -306,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "ppv-lite86"
@@ -351,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -400,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -474,18 +473,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -514,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+checksum = "8a7f3f92a1da3d6b1d32245d0cbcbbab0cfc45996d8df619c42bccfa6d2bbb5f"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -545,9 +544,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -596,16 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -628,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -648,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -669,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "casper-node-launcher"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-launcher"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A binary which runs and upgrades the casper-node of the Casper network"

--- a/resources/maintainer_scripts/casper_node_launcher/casper-node-launcher.service
+++ b/resources/maintainer_scripts/casper_node_launcher/casper-node-launcher.service
@@ -2,17 +2,15 @@
 Description=Casper Node Launcher
 Documentation=https://docs.casperlabs.io
 After=network-online.target
-# We are allowing only 3 start attempts within 1000 secs (16 minutes 40 secs).
-# Time out from not finding peers takes around 7 minutes, so this gives 14 minutes and some extra.
 StartLimitBurst=3
-StartLimitIntervalSec=1000
+StartLimitIntervalSec=15
 
 [Service]
 Type=simple
 # Enabling old network
 Environment="CASPER_ENABLE_LEGACY_NET=TRUE"
 # StandardOutput can only append log files from systemd version 240 + (Ubuntu 20.04). Use ExecStart with redirection as workaround.
-#seperate stderr logging as it outputs non-JSON stack traces
+# seperate stderr logging as it outputs non-JSON stack traces
 ExecStart=/bin/sh -c 'exec /usr/bin/casper-node-launcher 1>> /var/log/casper/casper-node.log 2>> /var/log/casper/casper-node.stderr.log'
 Restart=on-failure
 RestartSec=1

--- a/resources/maintainer_scripts/delete_local_db.sh
+++ b/resources/maintainer_scripts/delete_local_db.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Clears local data for use before changing chain runs.
-rm -rf /var/lib/casper/casper-node
+rm /var/lib/casper/casper-node/*.lmdb*

--- a/resources/maintainer_scripts/pull_casper_node_version.sh
+++ b/resources/maintainer_scripts/pull_casper_node_version.sh
@@ -7,7 +7,7 @@ set -e
 
 if [ -z "$1" ]; then
   echo "Error: version argument missing"
-  echo "Expected argument containing semantic version of casper_node with underscores as 1_0_2."
+  echo "Expected argument containing semantic version of casper_node with underscores such as 1_0_2."
   exit 1
 fi
 
@@ -30,16 +30,6 @@ fi
 ETC_FULL_PATH="$ETC_PATH/$SEMVER"
 BIN_FULL_PATH="$BIN_PATH/$SEMVER"
 
-if [ -d "$ETC_FULL_PATH" ]; then
-  echo "Error: config version path $ETC_FULL_PATH already exists. Aborting."
-  exit 4
-fi
-
-if [ -d "$BIN_FULL_PATH" ]; then
-  echo "Error: bin version path $BIN_FULL_PATH already exists. Aborting."
-  exit 5
-fi
-
 BASE_URL="http://genesis.casperlabs.io/$NETWORK/$SEMVER"
 CONFIG_ARCHIVE="config.tar.gz"
 CONFIG_URL="$BASE_URL/$CONFIG_ARCHIVE"
@@ -48,13 +38,35 @@ BIN_URL="$BASE_URL/$BIN_ARCHIVE"
 
 cd $ETC_PATH
 
+echo "Verifying semver Path"
+curl -I 2>/dev/null "$CONFIG_URL" | head -1 | grep 404 >/dev/null
+if [ $? == 0 ]; then
+  echo "$CONFIG_URL not found.  Please verify provided semver argument: $SEMVER"
+  exit 4
+fi
+curl -I 2>/dev/null "$BIN_URL" | head -1 | grep 404 >/dev/null
+if [ $? == 0 ]; then
+  echo "$BIN_URL not found.  Please verify provided semver argument: $SEMVER"
+  exit 5
+fi
+
+if [ -d "$ETC_FULL_PATH" ]; then
+  echo "Error: config version path $ETC_FULL_PATH already exists. Aborting."
+  exit 6
+fi
+
+if [ -d "$BIN_FULL_PATH" ]; then
+  echo "Error: bin version path $BIN_FULL_PATH already exists. Aborting."
+  exit 7
+fi
+
 echo "Downloading $CONFIG_ARCHIVE from $CONFIG_URL"
 if curl -JLO "$CONFIG_URL"; then
   echo "Complete"
 else
   echo "Error: unable to pull $CONFIG_ARCHIVE from $CONFIG_URL."
   echo "File probably doesn't exist.  Please verify version used: $SEMVER"
-  exit 6
+  exit 8
 fi
 CONFIG_ARCHIVE_PATH="$ETC_PATH/$CONFIG_ARCHIVE"
 
@@ -64,7 +76,7 @@ if curl -JLO "$BIN_URL"; then
 else
   echo "Error: unable to pull $BIN_ARCHIVE from $BIN_URL"
   echo "File probably doesn't exist.  Please verify version used: $SEMVER"
-  exit 7
+  exit 9
 fi
 BIN_ARCHIVE_PATH="$ETC_PATH/$BIN_ARCHIVE"
 


### PR DESCRIPTION
Correcting too long of a restart allowance.  This was locking start without clearing for short errors.
No longer removing unit files with delete_local_db.sh
Added 404 detection for pull_casper_node_version.sh script.  This is usually caused by user giving the wrong semver arg.