### PR TITLE
Added casper-test network config

### DIFF
--- a/resources/maintainer_scripts/network_configs/casper-test.conf
+++ b/resources/maintainer_scripts/network_configs/casper-test.conf
@@ -1,0 +1,2 @@
+SOURCE_URL=casper-genesis.make.services
+NETWORK_NAME=casper-test


### PR DESCRIPTION
As the title says, I added a new network config for the ```casper-test``` network. The config will be hosted at [https://casper-genesis.make.services](https://casper-genesis.make.services)